### PR TITLE
Add checks for ercrecover to make sure returned address is not 0

### DIFF
--- a/packages/contracts/contracts/YETI/YETIToken.sol
+++ b/packages/contracts/contracts/YETI/YETIToken.sol
@@ -173,7 +173,7 @@ contract YETIToken is IYETIToken {
                 _PERMIT_TYPEHASH, owner, spender, amount,
                 _nonces[owner]++, deadline))));
         address recoveredAddress = ecrecover(digest, v, r, s);
-        require(recoveredAddress == owner, 'YETI: invalid signature');
+        require(recoveredAddress == owner || recoveredAddress != address(0) , 'YUSD: invalid signature');
         _approve(owner, spender, amount);
     }
 

--- a/packages/contracts/contracts/YUSDToken.sol
+++ b/packages/contracts/contracts/YUSDToken.sol
@@ -202,7 +202,7 @@ contract YUSDToken is CheckContract, IYUSDToken {
                          _PERMIT_TYPEHASH, owner, spender, amount, 
                          _nonces[owner]++, deadline))));
         address recoveredAddress = ecrecover(digest, v, r, s);
-        require(recoveredAddress == owner, 'YUSD: invalid signature');
+        require(recoveredAddress == owner || recoveredAddress != address(0) , 'YUSD: invalid signature');
         _approve(owner, spender, amount);
     }
 


### PR DESCRIPTION
### Purpose

Check to make sure ecrecover doesn't fail and return `address(0)`
https://github.com/code-423n4/2021-12-yetifinance-findings/issues/244

### Open Questions and Pre-Merge TODOs
- [ ]

### Testing Methodology
`npx hardhat compile`

### Learning