### PR TITLE
Changes to wrapped assets to keep track of balance correctly. WBQI and WAAVE not complete yet.

### DIFF
--- a/packages/contracts/contracts/ActivePool.sol
+++ b/packages/contracts/contracts/ActivePool.sol
@@ -180,16 +180,14 @@ contract ActivePool is Ownable, CheckContract, IActivePool, YetiCustomBase {
     // Returns true if all payments were successfully sent. Must be called by borrower operations, trove manager, or stability pool.
     // This function als ounwraps the collaterals and sends them to _to, if they are wrapped assets. If collect rewards is set to true,
     // It also harvests rewards on the user's behalf. 
-    function sendCollateralsUnwrap(address _to, address[] calldata _tokens, uint[] calldata _amounts, bool _collectRewards) external override returns (bool) {
+    function sendCollateralsUnwrap(address _to, address[] calldata _tokens, uint[] calldata _amounts) external override returns (bool) {
         _requireCallerIsBOorTroveMorTMLorSP();
         uint256 len = _tokens.length;
         require(len == _amounts.length, "AP:Lengths");
         for (uint256 i; i < len; ++i) {
             if (whitelist.isWrapped(_tokens[i])) {
+                // Collects rewards automatically for that amount and unwraps for the original borrower. 
                 IWAsset(_tokens[i]).unwrapFor(_to, _amounts[i]);
-                if (_collectRewards) {
-                    IWAsset(_tokens[i]).claimRewardFor(_to);
-                }
             } else {
                 _sendCollateral(_to, _tokens[i], _amounts[i]); // reverts if send fails
             }

--- a/packages/contracts/contracts/ActivePool.sol
+++ b/packages/contracts/contracts/ActivePool.sol
@@ -180,14 +180,15 @@ contract ActivePool is Ownable, CheckContract, IActivePool, YetiCustomBase {
     // Returns true if all payments were successfully sent. Must be called by borrower operations, trove manager, or stability pool.
     // This function als ounwraps the collaterals and sends them to _to, if they are wrapped assets. If collect rewards is set to true,
     // It also harvests rewards on the user's behalf. 
-    function sendCollateralsUnwrap(address _to, address[] calldata _tokens, uint[] calldata _amounts) external override returns (bool) {
+    // _from is where the reward balance is, _to is where to send the tokens. 
+    function sendCollateralsUnwrap(address _from, address _to, address[] calldata _tokens, uint[] calldata _amounts) external override returns (bool) {
         _requireCallerIsBOorTroveMorTMLorSP();
         uint256 len = _tokens.length;
         require(len == _amounts.length, "AP:Lengths");
         for (uint256 i; i < len; ++i) {
             if (whitelist.isWrapped(_tokens[i])) {
                 // Collects rewards automatically for that amount and unwraps for the original borrower. 
-                IWAsset(_tokens[i]).unwrapFor(_to, _amounts[i]);
+                IWAsset(_tokens[i]).unwrapFor(_from, _to, _amounts[i]);
             } else {
                 _sendCollateral(_to, _tokens[i], _amounts[i]); // reverts if send fails
             }

--- a/packages/contracts/contracts/AssetWrappers/ERC20_8.sol
+++ b/packages/contracts/contracts/AssetWrappers/ERC20_8.sol
@@ -62,7 +62,7 @@ contract ERC20_8 is IERC20 {
     // - Owner's account must have sufficient balance to transfer
     // - 0 value transfers are allowed
     // ------------------------------------------------------------------------
-    function transfer(address _to, uint _num_tokens) public override returns (bool success) {
+    function transfer(address _to, uint _num_tokens) public virtual override returns (bool success) {
         require(_num_tokens <= balances[msg.sender], "You are trying to transfer more tokens than you have");
 
         unchecked { balances[msg.sender] = balances[msg.sender] - _num_tokens; } // pre checked that you have enough tokens
@@ -109,7 +109,7 @@ contract ERC20_8 is IERC20 {
     // - Spender must have sufficient allowance to transfer
     // - 0 value transfers are allowed
     // ------------------------------------------------------------------------
-    function transferFrom(address _from, address _to, uint _amount) public override returns (bool success) {
+    function transferFrom(address _from, address _to, uint _amount) public virtual override returns (bool success) {
         return _transferFrom(_from, _to, _amount);
     }
 

--- a/packages/contracts/contracts/AssetWrappers/Interfaces/IWAsset.sol
+++ b/packages/contracts/contracts/AssetWrappers/Interfaces/IWAsset.sol
@@ -6,11 +6,11 @@ pragma solidity 0.8.7;
 // Wrapped Asset
 interface IWAsset {
 
-    function wrap(uint _amount, address _to, address _rewardOwner) external;
+    function wrap(uint _amount, address _from, address _to, address _rewardOwner) external;
 
     function unwrap(uint amount) external;
 
-    function unwrapFor(address _for, uint amount) external;
+    function unwrapFor(address _from, address _to, uint amount) external;
 
     function updateReward(address from, address to, uint amount) external;
 

--- a/packages/contracts/contracts/AssetWrappers/Interfaces/IWAsset.sol
+++ b/packages/contracts/contracts/AssetWrappers/Interfaces/IWAsset.sol
@@ -6,7 +6,7 @@ pragma solidity 0.8.7;
 // Wrapped Asset
 interface IWAsset {
 
-    function wrap(uint _amount, address _to) external;
+    function wrap(uint _amount, address _to, address _rewardOwner) external;
 
     function unwrap(uint amount) external;
 

--- a/packages/contracts/contracts/AssetWrappers/Interfaces/IWAsset.sol
+++ b/packages/contracts/contracts/AssetWrappers/Interfaces/IWAsset.sol
@@ -16,11 +16,9 @@ interface IWAsset {
 
     function claimReward(address _to) external;
 
-    function claimRewardFor(address _for) external;
-
     function getPendingRewards(address _for) external view returns (address[] memory tokens, uint[] memory amounts);
 
     function getUserInfo(address _user) external returns (uint, uint, uint);
 
-    function endTreasuryReward(uint _amount) external;
+    function endTreasuryReward(address _to, uint _amount) external;
 }

--- a/packages/contracts/contracts/AssetWrappers/WAAVE.sol
+++ b/packages/contracts/contracts/AssetWrappers/WAAVE.sol
@@ -97,7 +97,7 @@ contract WAAVE is ERC20_8, IWAsset {
 
     function aavePerShare() public view returns (uint) {
         if (_totalSupply==0) {
-            return 1;
+            return 1e18;
         }
         return 1e18*aToken.balanceOf(address(this))/_totalSupply;
     }
@@ -134,7 +134,7 @@ contract WAAVE is ERC20_8, IWAsset {
     // the rewards these funds are earning are allocated Yeti Finance Treasury.
     // But when an stabilityPool depositor wants to withdraw their collateral,
     // the wAsset is unwrapped and the rewards are no longer accruing to the Yeti Finance Treasury
-    function endTreasuryReward(uint _amount) external override {
+    function endTreasuryReward(address _to, uint _amount) external override {
         _requireCallerIsSP();
     }
 
@@ -177,14 +177,6 @@ contract WAAVE is ERC20_8, IWAsset {
         // _sendReward(msg.sender, _to);
     }
 
-
-    // Only callable by ActivePool.
-    // Claims reward on behalf of a borrower as part of the process
-    // of withdrawing a wrapped asset from borrower's trove
-    function claimRewardFor(address _for) external override {
-        _requireCallerIsActivePool();
-
-    }
 
 
   

--- a/packages/contracts/contracts/AssetWrappers/WAAVE.sol
+++ b/packages/contracts/contracts/AssetWrappers/WAAVE.sol
@@ -87,7 +87,7 @@ contract WAAVE is ERC20_8, IWAsset {
     // to mint WAssets which it sends to _to. It also updates
     // _rewardOwner's reward tracking such that it now has the right to
     // future yields from the newly minted WAssets
-    function wrap(uint _amount, address _to) external override {
+    function wrap(uint _amount, address _to, address _rewardRecipient) external override {
         
         _mint(_to, 1e18*_amount/aavePerShare());
         aToken.transferFrom(msg.sender, address(this), _amount);

--- a/packages/contracts/contracts/AssetWrappers/WAAVE.sol
+++ b/packages/contracts/contracts/AssetWrappers/WAAVE.sol
@@ -87,7 +87,7 @@ contract WAAVE is ERC20_8, IWAsset {
     // to mint WAssets which it sends to _to. It also updates
     // _rewardOwner's reward tracking such that it now has the right to
     // future yields from the newly minted WAssets
-    function wrap(uint _amount, address _to, address _rewardRecipient) external override {
+    function wrap(uint _amount, address _from, address _to, address _rewardRecipient) external override {
         
         _mint(_to, 1e18*_amount/aavePerShare());
         aToken.transferFrom(msg.sender, address(this), _amount);
@@ -107,8 +107,6 @@ contract WAAVE is ERC20_8, IWAsset {
         aToken.transfer(msg.sender, _amount*aavePerShare()/1e18);
     }
 
-   
-
 
     // Only callable by ActivePool or StabilityPool
     // Used to provide unwrap assets during:
@@ -117,7 +115,7 @@ contract WAAVE is ERC20_8, IWAsset {
     // In both cases, the wrapped asset is first sent to the liquidator or redeemer respectively,
     // then this function is called with _for equal to the the liquidator or redeemer address
     // Prior to this being called, the user whose assets we are burning should have their rewards updated
-    function unwrapFor(address _to, uint _amount) external override {
+    function unwrapFor(address _from, address _to, uint _amount) external override {
         _requireCallerIsAPorSP();
         // accumulateRewards(msg.sender);
         // _MasterChefJoe.withdraw(_poolPid, _amount);

--- a/packages/contracts/contracts/AssetWrappers/WAAVE.sol
+++ b/packages/contracts/contracts/AssetWrappers/WAAVE.sol
@@ -37,11 +37,6 @@ contract WAAVE is ERC20_8, IWAsset {
     // Info of each user that stakes LP tokens.
     mapping(address => UserInfo) userInfo;
 
-    // Types of minting
-    mapping(uint => address) mintType;
-
-
-
 
     /* ========== INITIALIZER ========== */
 

--- a/packages/contracts/contracts/AssetWrappers/WBQI.sol
+++ b/packages/contracts/contracts/AssetWrappers/WBQI.sol
@@ -48,10 +48,6 @@ contract WBQI is ERC20_8, IWAsset {
     // Info of each user that stakes LP tokens.
     mapping(address => UserInfo) userInfo;
 
-    // Types of minting
-    mapping(uint => address) mintType;
-
-
     // Global rewards (numerator) that accounts for rewards/share paid out
     // Basically balanceOf(this)-globalAVAXRewardPending=cumulativePendingRewards
     uint public globalAVAXRewardPending;

--- a/packages/contracts/contracts/AssetWrappers/WBQI.sol
+++ b/packages/contracts/contracts/AssetWrappers/WBQI.sol
@@ -107,7 +107,7 @@ contract WBQI is ERC20_8, IWAsset {
     // to mint WAssets which it sends to _to. It also updates
     // _rewardOwner's reward tracking such that it now has the right to
     // future yields from the newly minted WAssets
-    function wrap(uint _amount, address _to, address _rewardRecipient) external override {
+    function wrap(uint _amount, address _from, address _to, address _rewardRecipient) external override {
         
         //Update rewards
 
@@ -164,7 +164,7 @@ contract WBQI is ERC20_8, IWAsset {
     // In both cases, the wrapped asset is first sent to the liquidator or redeemer respectively,
     // then this function is called with _for equal to the the liquidator or redeemer address
     // Prior to this being called, the user whose assets we are burning should have their rewards updated
-    function unwrapFor(address _to, uint _amount) external override {
+    function unwrapFor(address _to, address _from, uint _amount) external override {
         _requireCallerIsAPorSP();
         // accumulateRewards(msg.sender);
         // _MasterChefJoe.withdraw(_poolPid, _amount);

--- a/packages/contracts/contracts/AssetWrappers/WBQI.sol
+++ b/packages/contracts/contracts/AssetWrappers/WBQI.sol
@@ -107,7 +107,7 @@ contract WBQI is ERC20_8, IWAsset {
     // to mint WAssets which it sends to _to. It also updates
     // _rewardOwner's reward tracking such that it now has the right to
     // future yields from the newly minted WAssets
-    function wrap(uint _amount, address _to) external override {
+    function wrap(uint _amount, address _to, address _rewardRecipient) external override {
         
         //Update rewards
 

--- a/packages/contracts/contracts/AssetWrappers/WBQI.sol
+++ b/packages/contracts/contracts/AssetWrappers/WBQI.sol
@@ -181,9 +181,9 @@ contract WBQI is ERC20_8, IWAsset {
     // the rewards these funds are earning are allocated Yeti Finance Treasury.
     // But when an stabilityPool depositor wants to withdraw their collateral,
     // the wAsset is unwrapped and the rewards are no longer accruing to the Yeti Finance Treasury
-    function endTreasuryReward(uint _amount) external override {
+    function endTreasuryReward(address _to, uint _amount) external override {
         _requireCallerIsSP();
-        
+        // TODO 
         accumulateRewards(YetiFinanceTreasury);
         userInfo[YetiFinanceTreasury].amount = userInfo[YetiFinanceTreasury].amount - _amount;
     }
@@ -227,14 +227,6 @@ contract WBQI is ERC20_8, IWAsset {
         _sendReward(msg.sender, _to);
     }
 
-
-    // Only callable by ActivePool.
-    // Claims reward on behalf of a borrower as part of the process
-    // of withdrawing a wrapped asset from borrower's trove
-    function claimRewardFor(address _for) external override {
-        _requireCallerIsActivePool();
-        _sendReward(_for, _for);
-    }
 
 
     function _sendReward(address _rewardOwner, address _to) internal {

--- a/packages/contracts/contracts/AssetWrappers/WJLP.sol
+++ b/packages/contracts/contracts/AssetWrappers/WJLP.sol
@@ -135,10 +135,15 @@ contract WJLP is ERC20_8, IWAsset {
     /* ========== New Functions =============== */
 
     // Can be called by anyone.
-    // This function pulls in _amount base tokens from _from, then stakes them in
-    // to mint WAssets which it sends to _to. It also updates
-    // _rewardOwner's reward tracking such that it now has the right to
-    // future yields from the newly minted WAssets
+    // This function pulls in _amount of base JLP tokens from _from, and stakes 
+    // them in the reward contract, while updating the reward balance for that user. 
+    // Sends reward balance to _rewardRecipient, and the ability to withdraw from the 
+    // contract and get your JLP back is tracked by wJLP balance, and given to _to. 
+    // If the caller is not borrower operations, then _from and msg.sender must be 
+    // the same to make it so you must be the one wrapping your tokens. 
+    // Intended for use by Yeti Finance so that users can collateralize their LP tokens 
+    // while gaining yield. So the protocol owns wJLP while the user owns the reward balance 
+    // and can claim their JOE rewards any time. 
     function wrap(uint _amount, address _from, address _to, address _rewardRecipient) external override {
         if (msg.sender != borrowerOperations) {
             // Unless the caller is borrower operations, msg.sender and _from cannot 

--- a/packages/contracts/contracts/AssetWrappers/WJLP.sol
+++ b/packages/contracts/contracts/AssetWrappers/WJLP.sol
@@ -78,9 +78,6 @@ contract WJLP is ERC20_8, IWAsset {
     // Info of each user that stakes LP tokens.
     mapping(address => UserInfo) userInfo;
 
-    // Types of minting
-    mapping(uint => address) mintType;
-
     /* ========== INITIALIZER ========== */
 
     constructor(string memory ERC20_symbol,

--- a/packages/contracts/contracts/BorrowerOperations.sol
+++ b/packages/contracts/contracts/BorrowerOperations.sol
@@ -770,7 +770,7 @@ contract BorrowerOperations is LiquityBase, Ownable, CheckContract, IBorrowerOpe
         // in case of unlever up
         if (params._isUnlever) {
             // 1. withdraw the collateral from the active pool and perform the swap using single unlever up and corresponding router
-            contractsCache.activePool.sendCollateralsUnwrap(msg.sender, params._collsOut, params._amountsOut);
+            contractsCache.activePool.sendCollateralsUnwrap(msg.sender, msg.sender, params._collsOut, params._amountsOut);
 
             // 2. requires that the user has approved the contract to send its collateral if it is unlevering that amount. 
             uint256 collsLen = params._collsOut.length;
@@ -807,7 +807,7 @@ contract BorrowerOperations is LiquityBase, Ownable, CheckContract, IBorrowerOpe
             );
 
             // transfer withdrawn collateral to msg.sender from ActivePool
-            activePool.sendCollateralsUnwrap(msg.sender, params._collsOut, params._amountsOut);
+            activePool.sendCollateralsUnwrap(msg.sender, msg.sender, params._collsOut, params._amountsOut);
         }
     }
 
@@ -911,7 +911,7 @@ contract BorrowerOperations is LiquityBase, Ownable, CheckContract, IBorrowerOpe
         uint finalYUSDAmount;
         uint YUSDAmount;
         if (params._isUnlever) {
-            contractsCache.activePool.sendCollateralsUnwrap(msg.sender, colls, amounts);
+            contractsCache.activePool.sendCollateralsUnwrap(msg.sender, msg.sender, colls, amounts);
             // tracks the amount of YUSD that is received from swaps. Will send the _YUSDAmount back to repay debt while keeping remainder.
             
             // requires that the user has approved the contract to send its collateral if it is unlevering that amount. 
@@ -944,7 +944,7 @@ contract BorrowerOperations is LiquityBase, Ownable, CheckContract, IBorrowerOpe
         // Send the collateral back to the user
         // Also sends the rewards
         if (!params._isUnlever) {
-            contractsCache.activePool.sendCollateralsUnwrap(msg.sender, colls, amounts);
+            contractsCache.activePool.sendCollateralsUnwrap(msg.sender, msg.sender, colls, amounts);
         }
     }
 
@@ -1043,7 +1043,7 @@ contract BorrowerOperations is LiquityBase, Ownable, CheckContract, IBorrowerOpe
         if (whitelist.isWrapped(_coll)) {
             // If wrapped asset then it wraps it and sends the wrapped version to the active pool, 
             // and updates reward balance to the new owner. 
-            IWAsset(_coll).wrap(_amount, address(activePool), _from); 
+            IWAsset(_coll).wrap(_amount, _from, address(activePool), _from); 
         } else {
             require(IERC20(_coll).transferFrom(_from, address(activePool), _amount), "BO:TransferCollsFailed");
         }

--- a/packages/contracts/contracts/BorrowerOperations.sol
+++ b/packages/contracts/contracts/BorrowerOperations.sol
@@ -323,7 +323,7 @@ contract BorrowerOperations is LiquityBase, Ownable, CheckContract, IBorrowerOpe
         IYetiRouter router = IYetiRouter(whitelist.getDefaultRouterAddress(_token));
         // leverage is 5e18 for 5x leverage. Minus 1 for what the user already has in collateral value.
         uint _additionalTokenAmount = _amount.mul(_leverage.sub(1e18)).div(1e18); 
-        _additionalYUSDDebt = whitelist.getValueVC(_token, _additionalTokenAmount);
+        _additionalYUSDDebt = whitelist.getValueUSD(_token, _additionalTokenAmount);
 
         // 1/(1-1/ICR) = leverage. (1 - 1/ICR) = 1/leverage
         // 1 - 1/leverage = 1/ICR. ICR = 1/(1 - 1/leverage) = (1/((leverage-1)/leverage)) = leverage / (leverage - 1)
@@ -769,18 +769,10 @@ contract BorrowerOperations is LiquityBase, Ownable, CheckContract, IBorrowerOpe
 
         // in case of unlever up
         if (params._isUnlever) {
-            // 1. withdraw the collateral from the active pool and perform the swap using single unlever up and corresponding router
-            contractsCache.activePool.sendCollateralsUnwrap(msg.sender, msg.sender, params._collsOut, params._amountsOut);
+            // 1. Withdraw the collateral from active pool and perform swap using single unlever up and corresponding router. 
+            _unleverColls(contractsCache.activePool, params._collsOut, params._amountsOut, params._maxSlippages);
 
-            // 2. requires that the user has approved the contract to send its collateral if it is unlevering that amount. 
-            uint256 collsLen = params._collsOut.length;
-            for (uint256 i; i < collsLen; ++i) {
-                if (params._maxSlippages[i] != 0) {
-                    // add YUSD Amount from swap to total YUSD amount to repay debt
-                    _singleUnleverUp(params._collsOut[i], params._amountsOut[i], params._maxSlippages[i]);
-                } 
-            }
-            // 3. update the trove with the new collateral and debt, repaying the total amount of YUSD specified. 
+            // 2. update the trove with the new collateral and debt, repaying the total amount of YUSD specified. 
             // if not enough coll sold for YUSD, must cover from user balance
             _requireAtLeastMinNetDebt(_getNetDebt(vars.debt).sub(params._YUSDChange));
             _requireValidYUSDRepayment(vars.debt, params._YUSDChange);
@@ -823,14 +815,34 @@ contract BorrowerOperations is LiquityBase, Ownable, CheckContract, IBorrowerOpe
         // It should actually transfer to the owner, who will have bOps pre approved
         // cause of original approve
         IYetiRouter router = IYetiRouter(whitelist.getDefaultRouterAddress(_token));
-        // then calculate VC amount of expected YUSD output based on amount of token to sell
+        // then calculate value amount of expected YUSD output based on amount of token to sell
 
-        uint VCofCollateral = whitelist.getValueVC(_token, _amount);
-        uint256 slippageAdjustedValue = VCofCollateral.mul(DECIMAL_PRECISION.sub(_maxSlippage)).div(1e18);
+        uint valueOfCollateral = whitelist.getValueUSD(_token, _amount);
+        uint256 slippageAdjustedValue = valueOfCollateral.mul(DECIMAL_PRECISION.sub(_maxSlippage)).div(1e18);
         IERC20 yusdTokenCached = yusdToken;
-        uint256 balanceBefore = yusdToken.balanceOf(msg.sender);
-        _finalYUSDAmount = router.unRoute(msg.sender, _token, address(yusdTokenCached), _amount, slippageAdjustedValue);
-        require(yusdTokenCached.balanceOf(msg.sender) == balanceBefore.add(_finalYUSDAmount), "BO:YUSDNotSentUnLever");
+        require(IERC20(_token).approve(address(router), valueOfCollateral));
+        uint256 balanceBefore = yusdToken.balanceOf(address(this));
+        _finalYUSDAmount = router.unRoute(address(this), _token, address(yusdTokenCached), _amount, slippageAdjustedValue);
+        require(yusdTokenCached.balanceOf(address(this)) == balanceBefore.add(_finalYUSDAmount), "BO:YUSDNotSentUnLever");
+    }
+
+    // Takes the colls and amounts, transfer non levered from the active pool to the user, and unlevered to this contract 
+    // temporarily. Then takes the unlevered ones and calls relevant router to swap them to the user. 
+    function _unleverColls(
+        IActivePool _activePool, 
+        address[] memory _colls, 
+        uint256[] memory _amounts, 
+        uint256[] memory _maxSlippages
+    ) internal {
+        uint256 collsLen = _colls.length;
+        for (uint256 i; i < collsLen; ++i) {
+            if (_maxSlippages[i] != 0) {
+                _activePool.sendSingleCollateral(address(this), _colls[i], _amounts[i]);
+                _singleUnleverUp(_colls[i], _amounts[i], _maxSlippages[i]);
+            } else {
+                _activePool.sendSingleCollateralUnwrap(msg.sender, msg.sender, _colls[i], _amounts[i]);
+            }
+        }
     }
 
 
@@ -911,17 +923,9 @@ contract BorrowerOperations is LiquityBase, Ownable, CheckContract, IBorrowerOpe
         uint finalYUSDAmount;
         uint YUSDAmount;
         if (params._isUnlever) {
-            contractsCache.activePool.sendCollateralsUnwrap(msg.sender, msg.sender, colls, amounts);
+            // Withdraw the collateral from active pool and perform swap using single unlever up and corresponding router. 
+            _unleverColls(contractsCache.activePool, colls, amounts, params._maxSlippages);
             // tracks the amount of YUSD that is received from swaps. Will send the _YUSDAmount back to repay debt while keeping remainder.
-            
-            // requires that the user has approved the contract to send its collateral if it is unlevering that amount. 
-            uint256 collsLen = params._collsOut.length;
-            for (uint256 i; i < collsLen; ++i) {
-                if (params._maxSlippages[i] != 0) {
-                    // add YUSD Amount from swap to total YUSD amount to repay debt
-                    _singleUnleverUp(params._collsOut[i], params._amountsOut[i], params._maxSlippages[i]);
-                } 
-            }   
         }
 
         // do check after unlever (if applies)

--- a/packages/contracts/contracts/CollSurplusPool.sol
+++ b/packages/contracts/contracts/CollSurplusPool.sol
@@ -201,7 +201,7 @@ contract CollSurplusPool is Ownable, CheckContract, ICollSurplusPool, LiquityBas
             if (whitelist.isWrapped(token)) {
                 // Collects rewards automatically for that amount and unwraps for the original borrower. 
                 // CSP actually owns these assets so it transfers it from this contract to the _to param. 
-                IWAsset(token).unwrapFor(_to, _colls.amounts[i]);
+                IWAsset(token).unwrapFor(_to, _to, _colls.amounts[i]);
             } else {
                 // Otherwise transfer like normal ERC20
                 if (!IERC20(token).transfer(_to, _colls.amounts[i])) {

--- a/packages/contracts/contracts/CollSurplusPool.sol
+++ b/packages/contracts/contracts/CollSurplusPool.sol
@@ -8,6 +8,7 @@ import "./Dependencies/SafeMath.sol";
 import "./Dependencies/Ownable.sol";
 import "./Dependencies/CheckContract.sol";
 import "./Dependencies/LiquityBase.sol";
+import "./Interfaces/IWAsset.sol";
 
 
 /**
@@ -189,5 +190,25 @@ contract CollSurplusPool is Ownable, CheckContract, ICollSurplusPool, LiquityBas
         _requireCallerIsWhitelist();
         poolColl.tokens.push(_collateral);
         poolColl.amounts.push(0);
+    }
+
+    // Function to send collateral out to an address, and checks if the asset is wrapped so that it can 
+    // unwrap in that case. 
+    function _sendColl(address _to, newColls memory _colls) internal returns (bool) {
+        uint256 tokensLen = _colls.tokens.length;
+        for (uint256 i; i < tokensLen; ++i) {
+            address token = _colls.tokens[i];
+            if (whitelist.isWrapped(token)) {
+                // Collects rewards automatically for that amount and unwraps for the original borrower. 
+                // CSP actually owns these assets so it transfers it from this contract to the _to param. 
+                IWAsset(token).unwrapFor(_to, _colls.amounts[i]);
+            } else {
+                // Otherwise transfer like normal ERC20
+                if (!IERC20(token).transfer(_to, _colls.amounts[i])) {
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 }

--- a/packages/contracts/contracts/Dependencies/LiquityBase.sol
+++ b/packages/contracts/contracts/Dependencies/LiquityBase.sol
@@ -149,18 +149,6 @@ contract LiquityBase is ILiquityBase, YetiCustomBase {
     }
 
 
-    function _sendColl(address _to, newColls memory _colls) internal returns (bool) {
-        uint256 tokensLen = _colls.tokens.length;
-        for (uint256 i; i < tokensLen; ++i) {
-            IERC20 token = IERC20(_colls.tokens[i]);
-            if (!token.transfer(_to, _colls.amounts[i])) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-
     // Check whether or not the system *would be* in Recovery Mode, given the entire system coll and debt.
     // returns true if the system would be in recovery mode and false if not
     function _checkPotentialRecoveryMode(uint _entireSystemColl, uint _entireSystemDebt)

--- a/packages/contracts/contracts/Dependencies/LiquityBase.sol
+++ b/packages/contracts/contracts/Dependencies/LiquityBase.sol
@@ -54,16 +54,6 @@ contract LiquityBase is ILiquityBase, YetiCustomBase {
     }
 
 
-    // Return the amount of collateral to be drawn from a trove's collateral and sent as gas compensation.
-    function _getCollGasCompensation(newColls memory _coll) internal pure returns (newColls memory) {
-        require(_coll.tokens.length == _coll.amounts.length, "Not same length");
-
-        uint[] memory amounts = new uint[](_coll.tokens.length);
-        for (uint256 i; i < _coll.tokens.length; ++i) {
-            amounts[i] = _coll.amounts[i] / PERCENT_DIVISOR;
-        }
-        return newColls(_coll.tokens, amounts);
-    }
 
     // Return the system's Total Virtual Coin Balance
     // Virtual Coins are a way to keep track of the system collateralization given

--- a/packages/contracts/contracts/Interfaces/IActivePool.sol
+++ b/packages/contracts/contracts/Interfaces/IActivePool.sol
@@ -16,6 +16,7 @@ interface IActivePool is IPool {
     
     function sendCollaterals(address _to, address[] memory _tokens, uint[] memory _amounts) external returns (bool);
     function sendCollateralsUnwrap(
+        address _from,
         address _to,
         address[] memory _tokens,
         uint[] memory _amounts) external returns (bool);

--- a/packages/contracts/contracts/Interfaces/IActivePool.sol
+++ b/packages/contracts/contracts/Interfaces/IActivePool.sol
@@ -18,8 +18,7 @@ interface IActivePool is IPool {
     function sendCollateralsUnwrap(
         address _to,
         address[] memory _tokens,
-        uint[] memory _amounts,
-        bool _collectRewards) external returns (bool);
+        uint[] memory _amounts) external returns (bool);
     function getCollateralVC(address collateralAddress) external view returns (uint);
     function addCollateralType(address _collateral) external;
 }

--- a/packages/contracts/contracts/Interfaces/IActivePool.sol
+++ b/packages/contracts/contracts/Interfaces/IActivePool.sol
@@ -20,6 +20,11 @@ interface IActivePool is IPool {
         address _to,
         address[] memory _tokens,
         uint[] memory _amounts) external returns (bool);
+
+    function sendSingleCollateral(address _to, address _token, uint256 _amount) external returns (bool);
+
+    function sendSingleCollateralUnwrap(address _from, address _to, address _token, uint256 _amount) external returns (bool);
+
     function getCollateralVC(address collateralAddress) external view returns (uint);
     function addCollateralType(address _collateral) external;
 }

--- a/packages/contracts/contracts/Interfaces/IWAsset.sol
+++ b/packages/contracts/contracts/Interfaces/IWAsset.sol
@@ -6,9 +6,9 @@ pragma solidity 0.6.11;
 // Wrapped Asset
 interface IWAsset  {
 
-    function wrap(uint _amount, address _to, address _rewardOwner) external;
+    function wrap(uint _amount, address _from, address _to, address _rewardOwner) external;
     
-    function unwrapFor(address _for, uint amount) external;
+    function unwrapFor(address _from, address _to, uint amount) external;
 
     function updateReward(address from, address to, uint amount) external;
 

--- a/packages/contracts/contracts/Interfaces/IWAsset.sol
+++ b/packages/contracts/contracts/Interfaces/IWAsset.sol
@@ -18,5 +18,5 @@ interface IWAsset  {
 
     function getPendingRewards(address _for) external returns (address[] memory, uint[] memory);
 
-    function endTreasuryReward(uint _amount) external;
+    function endTreasuryReward(address _to, uint _amount) external;
 }

--- a/packages/contracts/contracts/Interfaces/IWAsset.sol
+++ b/packages/contracts/contracts/Interfaces/IWAsset.sol
@@ -6,8 +6,8 @@ pragma solidity 0.6.11;
 // Wrapped Asset
 interface IWAsset  {
 
-    function wrap(uint _amount, address _from, address _to, address _rewardOwner) external;
-
+    function wrap(uint _amount, address _to, address _rewardOwner) external;
+    
     function unwrapFor(address _for, uint amount) external;
 
     function updateReward(address from, address to, uint amount) external;

--- a/packages/contracts/contracts/Routers/WJLPRouter.sol
+++ b/packages/contracts/contracts/Routers/WJLPRouter.sol
@@ -95,7 +95,7 @@ contract WJLPRouter is IYetiRouter {
         address _fromUser,
         address _owner
     ) internal {
-        WJLP.wrap(_amount, activePoolAddress, _owner);
+        WJLP.wrap(_amount, address(this), activePoolAddress, _owner);
     }
 
     // takes avax and zaps it into the specific JLP token.

--- a/packages/contracts/contracts/Routers/WJLPRouter.sol
+++ b/packages/contracts/contracts/Routers/WJLPRouter.sol
@@ -95,7 +95,7 @@ contract WJLPRouter is IYetiRouter {
         address _fromUser,
         address _owner
     ) internal {
-        WJLP.wrap(_amount, _fromUser, activePoolAddress, _owner);
+        WJLP.wrap(_amount, activePoolAddress, _owner);
     }
 
     // takes avax and zaps it into the specific JLP token.

--- a/packages/contracts/contracts/StabilityPool.sol
+++ b/packages/contracts/contracts/StabilityPool.sol
@@ -945,13 +945,17 @@ contract StabilityPool is LiquityBase, Ownable, CheckContract, IStabilityPool {
         uint256 assetsLen = assets.length;
         require(assetsLen == amounts.length, "SP:Length mismatch");
         uint256 thisAmounts;
+        address thisAsset;
         for (uint256 i; i < assetsLen; ++i) {
             thisAmounts = amounts[i];
-            if (whitelist.isWrapped(assets[i])){
-                IWAsset(assets[i]).endTreasuryReward(thisAmounts);
-                IWAsset(assets[i]).unwrapFor(_to, thisAmounts);
+            thisAsset = assets[i];
+            if (whitelist.isWrapped(thisAsset)) {
+                // In this case update the rewards from the treasury to the caller 
+                IWAsset(thisAsset).endTreasuryReward(_to, thisAmounts);
+                // unwrapFor ends the rewards for the caller and transfers the tokens to the _to param. 
+                IWAsset(thisAsset).unwrapFor(_to, thisAmounts);
             } else {
-                IERC20(assets[i]).safeTransfer(_to, thisAmounts);
+                IERC20(thisAsset).safeTransfer(_to, thisAmounts);
             }
         }
         totalColl.amounts = _leftSubColls(totalColl, assets, amounts);

--- a/packages/contracts/contracts/StabilityPool.sol
+++ b/packages/contracts/contracts/StabilityPool.sol
@@ -951,9 +951,9 @@ contract StabilityPool is LiquityBase, Ownable, CheckContract, IStabilityPool {
             thisAsset = assets[i];
             if (whitelist.isWrapped(thisAsset)) {
                 // In this case update the rewards from the treasury to the caller 
-                IWAsset(thisAsset).endTreasuryReward(_to, thisAmounts);
+                IWAsset(thisAsset).endTreasuryReward(address(this), thisAmounts);
                 // unwrapFor ends the rewards for the caller and transfers the tokens to the _to param. 
-                IWAsset(thisAsset).unwrapFor(_to, thisAmounts);
+                IWAsset(thisAsset).unwrapFor(address(this), _to, thisAmounts);
             } else {
                 IERC20(thisAsset).safeTransfer(_to, thisAmounts);
             }

--- a/packages/contracts/contracts/TestContracts/CDPManagerTester.sol
+++ b/packages/contracts/contracts/TestContracts/CDPManagerTester.sol
@@ -109,4 +109,15 @@ contract TroveManagerTester is TroveManager {
         return _getUSDColls(coll);
     }
 
+    // Return the amount of collateral to be drawn from a trove's collateral and sent as gas compensation.
+    function _getCollGasCompensation(newColls memory _coll) internal pure returns (newColls memory) {
+        require(_coll.tokens.length == _coll.amounts.length, "Not same length");
+
+        uint[] memory amounts = new uint[](_coll.tokens.length);
+        for (uint256 i; i < _coll.tokens.length; ++i) {
+            amounts[i] = _coll.amounts[i] / PERCENT_DIVISOR;
+        }
+        return newColls(_coll.tokens, amounts);
+    }
+
 }

--- a/packages/contracts/contracts/TroveManagerLiquidations.sol
+++ b/packages/contracts/contracts/TroveManagerLiquidations.sol
@@ -407,9 +407,6 @@ contract TroveManagerLiquidations is TroveManagerBase, ITroveManagerLiquidations
             singleLiquidation.entireTroveColl
         );
 
-        // WAssets sent as liquidation reward will be unstaked and no longer accrue rewards
-        _updateWAssetsRewardOwner(singleLiquidation.collGasCompensation, _borrower, address(0));
-
         singleLiquidation.YUSDGasCompensation = YUSD_GAS_COMPENSATION;
 
         vars.collToLiquidate.tokens = singleLiquidation.entireTroveColl.tokens;
@@ -486,9 +483,6 @@ contract TroveManagerLiquidations is TroveManagerBase, ITroveManagerLiquidations
         singleLiquidation.collGasCompensation = _getCollGasCompensation(
             singleLiquidation.entireTroveColl
         );
-
-        // WAssets sent as liquidation reward will be unstaked and no longer accrue rewards
-        _updateWAssetsRewardOwner(singleLiquidation.collGasCompensation, _borrower, address(0));
 
         singleLiquidation.YUSDGasCompensation = YUSD_GAS_COMPENSATION;
 
@@ -851,7 +845,7 @@ contract TroveManagerLiquidations is TroveManagerBase, ITroveManagerLiquidations
             yusdTokenContract.returnFromPool(gasPoolAddress, _liquidator, _YUSD);
         }
 
-        _activePool.sendCollateralsUnwrap(_liquidator, _tokens, _amounts, false);
+        _activePool.sendCollateralsUnwrap(_liquidator, _tokens, _amounts);
     }
 
     /*

--- a/packages/contracts/contracts/TroveManagerRedemptions.sol
+++ b/packages/contracts/contracts/TroveManagerRedemptions.sol
@@ -266,8 +266,7 @@ contract TroveManagerRedemptions is TroveManagerBase, ITroveManagerRedemptions {
         contractsCache.activePool.sendCollateralsUnwrap(
             _redeemer,
             totals.CollsDrawn.tokens,
-            totals.CollsDrawn.amounts,
-            false
+            totals.CollsDrawn.amounts
         );
     }
 
@@ -319,17 +318,6 @@ contract TroveManagerRedemptions is TroveManagerBase, ITroveManagerRedemptions {
         require(troveManager.getCurrentICR(hints.target) >= MCR, "TMR:Trove is underwater");
         troveManager.applyPendingRewards(hints.target);
 
-        // SingleRedemptionValues memory singleRedemption = _redeemCollateralFromTrove(
-        //     contractsCache,
-        //     _redeemer,
-        //     currentBorrower,
-        //     totals.remainingYUSD,
-        //     _upperPartialRedemptionHint,
-        //     _lowerPartialRedemptionHint,
-        //     _partialRedemptionHintICR
-        // );
-
-
         // Stitched in _redeemCollateralFromTrove
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -377,11 +365,6 @@ contract TroveManagerRedemptions is TroveManagerBase, ITroveManagerRedemptions {
             uint tokenAmountToRedeem = singleRedemption.YUSDLot.mul(colls.amounts[i]).div(singleCollUSD);
             colls.amounts[i] = colls.amounts[i].sub(tokenAmountToRedeem);
             singleRedemption.CollLot.amounts[i] = tokenAmountToRedeem;
-            // if it is a wrapped asset we need to reduce reward. 
-            // Later the asset will be transferred directly out, so no new reward is needed to be kept track of
-            if (whitelist.isWrapped(colls.tokens[i])) {
-                IWAsset(colls.tokens[i]).updateReward(hints.target, msg.sender, tokenAmountToRedeem);
-            }
         }
 
         
@@ -500,8 +483,7 @@ contract TroveManagerRedemptions is TroveManagerBase, ITroveManagerRedemptions {
         contractsCache.activePool.sendCollateralsUnwrap(
             msg.sender,
             totals.CollsDrawn.tokens,
-            totals.CollsDrawn.amounts,
-            false
+            totals.CollsDrawn.amounts
         );
     }
 
@@ -551,11 +533,6 @@ contract TroveManagerRedemptions is TroveManagerBase, ITroveManagerRedemptions {
                 uint tokenAmountToRedeem = baseLot.mul(colls.amounts[i]).div(totalCollUSD).div(1e18);
                 finalAmounts[i] = colls.amounts[i].sub(tokenAmountToRedeem);
                 singleRedemption.CollLot.amounts[i] = tokenAmountToRedeem;
-                // if it is a wrapped asset we need to reduce reward. 
-                // Later the asset will be transferred directly out, so no new reward is needed to be kept track of
-                if (whitelist.isWrapped(colls.tokens[i])) {
-                    IWAsset(colls.tokens[i]).updateReward(_borrower, msg.sender, tokenAmountToRedeem);
-                }
             }
         }
 

--- a/packages/contracts/test/BorrowerOperationsTestMultiCollateral.js
+++ b/packages/contracts/test/BorrowerOperationsTestMultiCollateral.js
@@ -1456,7 +1456,7 @@ contract('BorrowerOperations', async accounts => {
             // it("") test max fee max(new debt in, collateral in)
         })
 
-        describe('Lever up', async () => {
+        describe.only('Lever up', async () => {
             beforeEach(async () => {
                 joeRouter = new ethers.Contract("0x60aE616a2155Ee3d9A68541Ba4544862310933d4", abi = routerABI, signer = await hre.ethers.getSigner(H));
                 await yusdToken.unprotectedMint(H, dec(100000000, 18));

--- a/packages/contracts/utils/deploymentHelpers.js
+++ b/packages/contracts/utils/deploymentHelpers.js
@@ -655,7 +655,9 @@ class DeploymentHelper {
       contracts.troveManagerRedemptions.address,
       contracts.defaultPool.address,
       contracts.stabilityPool.address,
-      YETIContracts.yetiFinanceTreasury.address
+      YETIContracts.yetiFinanceTreasury.address,
+      contracts.borrowerOperations.address,
+      contracts.collSurplusPool.address
     )
 
     await contracts.PriceCurveAVAX.setAddresses(contracts.whitelist.address)

--- a/packages/contracts/utils/testHelpers.js
+++ b/packages/contracts/utils/testHelpers.js
@@ -2220,7 +2220,7 @@ class TestHelper {
       partialRedemptionNewICR,
       maxIterations,
       // maxFee,
-      { from: redeemer, gasPrice: 10018651 },
+      { from: redeemer, gasPrice: 100879745 },
     )
 
     return tx


### PR DESCRIPTION
When collateral enters the system, it is transferFrom’d into the active pool by BorrowerOperations. Wrapped assets are to check if they have enough “reward balance” to ensure that the borrower actually has that reward balance and not just the token balance, on transferFrom. Now wrapped assets are owned by Active Pool but rewards are distributed to various borrowers. 

Simplest way to exit the system: BorrowerOperations closeTrove or adjustTrove. This just does an unwrapFor call, which takes the wrapped token from the active pool, unwraps it, transferring the underlying to the borrower. This claims rewards beforehand and updates the reward balance accordingly as well. 

Redemptions: All the collateral goes to the redeemer, so this is a similar unwrapFor call, where it transfers the balance to the redeemer. Requires some amount of reward balance from the original owner, but this exists due to how the collateral entered the system. Claims rewards beforehand and updates reward balance accordingly. 

Liquidations: For recovery and normal mode, this is the same. Some is sent to defaultPool, some to the stabilityPool, some to collSurplusPool, and some to the liquidator as the gas compensation. Explained below is what the flows are for these. 

For stabilityPool, we transfer reward balance to the treasury, and transfer the actual token balance to the stabilityPool based on the amounts. From stabilityPool, depositors can claim their rewards. So when they claim the rewards, some reward balance ends for the treasury (and the rewards are claimed), and new reward balance is given to the depositor so that it can unwrap for to transfer the underlying tokens to the depositor. 

For defaultPool, same deal with transferring reward to treasury. However, it all goes back to the activePool eventually, so we transfer the actual tokens to the activePool, while transferring the rewards from the treasury to the borrower. Then it is like a normal asset in the activePool. 

For collSurplusPool, just the balance is transferred. The procedure is similar to as if active pool owned it. This works the same for collateral given by redemptions as well. 

Finally the liquidator gets the gas comp, so it just is a normal unwrapFor call. 

For LeverUp as well to clarify: when the collateral enters the system in a “lever up “ mode, as it goes through the router now the router owns the wrapped asset and the reward. It transfers the collateral bought directly to the active pool, so the reward also updates to the original borrower, for the amount levered up by. 